### PR TITLE
Add inTab view and keyword highlighting

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -6,9 +6,12 @@
   <title>Keyword Finder</title>
   <style>
     body { font-family: sans-serif; margin: 10px; width: 500px; }
+    body.inTab { width: auto; }
     table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+    body.inTab table { width: auto; }
     th, td { border: 1px solid #ccc; padding: 5px; word-break: break-all; }
     th { background: #f5f5f5; }
+    #openInTabBtn { display: none; margin-bottom: 10px; }
     #progressContainer { margin-top: 10px; }
     #progressBar { width: 100%; }
     #status { margin-top: 5px; font-size: 0.9em; color: #555; }
@@ -16,6 +19,7 @@
 </head>
 <body>
   <h2>Keyword Finder</h2>
+  <button id="openInTabBtn">#inTab</button>
   <div>
     <label>URL 列表 (url.txt):</label><br>
     <input type="file" id="urlFile" accept=".txt"><br><br>

--- a/popup.js
+++ b/popup.js
@@ -24,6 +24,18 @@ function updateProgress(current, total, message) {
   console.log(message, current, '/', total);
 }
 
+// 转义 HTML 并高亮关键字
+function highlightKeywords(text, keywords) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  let escaped = div.innerHTML;
+  for (const kw of keywords) {
+    const reg = new RegExp(kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+    escaped = escaped.replace(reg, '<mark>$&</mark>');
+  }
+  return escaped;
+}
+
 // 主流程：读取 URL、关键字列表、抓取页面并搜索
 document.getElementById('runBtn').addEventListener('click', async () => {
   const urlFiles = document.getElementById('urlFile').files;
@@ -93,8 +105,9 @@ document.getElementById('runBtn').addEventListener('click', async () => {
             const anchor = url + fragment;
             console.log(`Found '${key}' in content:`, contentText);
             const row = document.createElement('tr');
+            const html = highlightKeywords(contentText, keys);
             row.innerHTML = `
-              <td>${contentText.replace(/</g, '&lt;')}</td>
+              <td>${html}</td>
               <td><a href="${anchor}" target="_blank">直达</a></td>
               <td><a href="${url}" target="_blank">${url}</a></td>
             `;
@@ -122,6 +135,16 @@ document.getElementById('clearCacheBtn').addEventListener('click', () => {
 
 // 页面加载时检查缓存
 document.addEventListener('DOMContentLoaded', () => {
+  if (location.hash === '#inTab') {
+    document.body.classList.add('inTab');
+  } else {
+    const btn = document.getElementById('openInTabBtn');
+    btn.style.display = 'inline-block';
+    btn.addEventListener('click', () => {
+      chrome.tabs.create({ url: chrome.runtime.getURL('popup.html#inTab') });
+    });
+  }
+
   const hasCache = localStorage.getItem('urls') && localStorage.getItem('keys');
   if (hasCache) {
     document.getElementById('progressContainer').hidden = false;


### PR DESCRIPTION
## Summary
- support an `#inTab` view for popup.html with full width layout
- highlight keywords in the results table
- add button to open the popup in a new tab

## Testing
- `node --check popup.js`

------
https://chatgpt.com/codex/tasks/task_b_68627ac3a0c4832eb4b290ef3bb9962d