### PR TITLE
Add text fragment highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # keyword-finder-extension
-keyword-finder-extension
+Chrome extension that searches a list of pages for keywords and generates
+direct links using the `#:~:text=` fragment.
+
+When a link with `#:~:text=` is opened, `contentScript.js` now reads the
+fragment text and highlights it on the destination page so the keyword
+snippet stays visible even after the browser's default highlight fades.

--- a/contentScript.js
+++ b/contentScript.js
@@ -33,16 +33,29 @@ function highlightDocument(keys) {
   }
 }
 
+// 从 URL 中解析 :~:text= 片段
+function getTextFragment() {
+  const match = location.href.match(/#:~:text=([^&]*)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 if (typeof chrome !== 'undefined' &&
     chrome.storage && chrome.storage.local) {
   chrome.storage.local.get('highlightData', data => {
     const info = data.highlightData;
-    if (!info) return;
-    const { url, keys } = info;
-    if (url && Array.isArray(keys) && location.href.startsWith(url)) {
-      highlightDocument(keys);
-      chrome.storage.local.remove('highlightData');
+    if (info) {
+      const { url, keys } = info;
+      if (url && Array.isArray(keys) && location.href.startsWith(url)) {
+        highlightDocument(keys);
+        chrome.storage.local.remove('highlightData');
+        return;
+      }
     }
+    const frag = getTextFragment();
+    if (frag) highlightDocument([frag]);
   });
+} else {
+  const frag = getTextFragment();
+  if (frag) highlightDocument([frag]);
 }
 


### PR DESCRIPTION
## Summary
- document extension usage in README
- highlight `:~:text` fragments when a page opens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686292662d5c832ea2fec088d34b3ac1