### PR TITLE
Add date and link detection

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,13 @@
 
   <table id="resultTable">
     <thead>
-      <tr><th>文本内容</th><th>直达链接</th><th>来源 URL</th></tr>
+      <tr>
+        <th>日期</th>
+        <th>文本内容</th>
+        <th>转到</th>
+        <th>直达链接</th>
+        <th>来源 URL</th>
+      </tr>
     </thead>
     <tbody></tbody>
   </table>

--- a/popup.js
+++ b/popup.js
@@ -38,6 +38,8 @@ document.getElementById('runBtn').addEventListener('click', async () => {
   const tbody = document.querySelector('#resultTable tbody');
   tbody.innerHTML = '';
 
+  const dateRegex = /\d{4}[年\/\-\.][0-1]?\d[月\/\-\.][0-3]?\d(?:日)?/;
+
   // 显示进度条
   const progressContainer = document.getElementById('progressContainer');
   progressContainer.hidden = false;
@@ -84,10 +86,23 @@ document.getElementById('runBtn').addEventListener('click', async () => {
             if (!parent.id) parent.id = `elem-${idx}-${Date.now()}`;
             const anchor = url + '#' + parent.id;
             console.log(`Found keyword '${key}' at position ${pos} text node ${idx}`);
-            const snippet = text.length > 200 ? text.slice(pos, pos + 200) + '...' : text;
+
+            const snippetStart = Math.max(0, pos - 50);
+            const snippetEnd = Math.min(text.length, pos + key.length + 150);
+            const snippet = text.slice(snippetStart, snippetEnd);
+
+            const dateMatch = snippet.match(dateRegex);
+            const date = dateMatch ? dateMatch[0] : '';
+
+            let link = '';
+            const linkElem = node.parentElement.closest('a');
+            if (linkElem) link = linkElem.href;
+
             const row = document.createElement('tr');
             row.innerHTML = `
+              <td>${date}</td>
               <td>${snippet.replace(/</g, '&lt;')}</td>
+              <td>${link ? `<a href="${link}" target="_blank">链接</a>` : ''}</td>
               <td><a href="${anchor}" target="_blank">直达</a></td>
               <td><a href="${url}" target="_blank">${url}</a></td>
             `;


### PR DESCRIPTION
## Summary
- extend result table with columns for date, links, and source
- capture dates near each matched text
- grab hyperlink if present and include in results

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68634d727bd4832e982b8e8e6902275c