### PR TITLE
Implement browser storage caching with update marks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "version": "1.0",
   "description": "从指定的 URL 列表中寻找关键字并生成直达链接",
   "permissions": [
+    "storage",
     "scripting",
     "activeTab"
   ],


### PR DESCRIPTION
## Summary
- add storage permission to manifest
- cache URLs, keys and table data in localStorage
- load stored results on popup open
- mark newly fetched rows with `*` in the date column

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_68636530f740832e9e864181dcaab9a6